### PR TITLE
Handle errors in OAuth endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1136,10 +1136,11 @@
       }
     },
     "@octokit/request-error": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
-      "integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.1.0.tgz",
+      "integrity": "sha512-06lt8PulL3rKpmwzYLCeLEt1iHFoj8l0PLkObAtp5Cx0Wwd1+5FAa9u6UXjA0kzYsfbjBKF9TtO9CuXelKiYlw==",
       "requires": {
+        "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@octokit/request": "^5.3.0",
     "@octokit/types": "^2.0.0",
+    "@octokit/request-error": "^1.1.0",
     "@types/lru-cache": "^5.1.0",
     "lru-cache": "^5.1.1",
     "universal-github-app-jwt": "^1.0.1",

--- a/src/get-oauth-authentication.ts
+++ b/src/get-oauth-authentication.ts
@@ -34,9 +34,17 @@ export async function getOAuthAuthentication(
     redirect_uri: options.redirectUrl
   };
 
+  const response = await request(route, parameters);
+
+  if (response.data.error !== undefined) {
+    throw new Error(
+      response.data.error_description || `Unknown error: ${response.data.error}`
+    );
+  }
+
   const {
     data: { access_token: token, scope }
-  } = await request(route, parameters);
+  } = response;
 
   return {
     type: "token",

--- a/src/get-oauth-authentication.ts
+++ b/src/get-oauth-authentication.ts
@@ -4,6 +4,7 @@ import {
   StrategyOptionsWithDefaults,
   OAuthAccesTokenAuthentication
 } from "./types";
+import { RequestError } from '@octokit/request-error';
 
 export async function getOAuthAuthentication(
   state: StrategyOptionsWithDefaults,
@@ -37,9 +38,10 @@ export async function getOAuthAuthentication(
   const response = await request(route, parameters);
 
   if (response.data.error !== undefined) {
-    throw new Error(
-      response.data.error_description || `Unknown error: ${response.data.error}`
-    );
+    throw new RequestError(`${response.data.error_description} (${response.data.error})`, response.status, {
+      headers: response.headers,
+      request: request.endpoint(route, parameters)
+    });
   }
 
   const {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1049,3 +1049,41 @@ test("auth.hook() creates token and uses it for succeeding requests", async () =
 
   expect(mock.done()).toBe(true);
 });
+
+
+test("oauth endpoint error", async () => {
+  const requestMock = request.defaults({
+    headers: {
+      "user-agent": "test"
+    },
+    request: {
+      fetch: fetchMock.sandbox().post(
+        "https://github.com/login/oauth/access_token", {
+          status: 200,
+          body: JSON.stringify({
+            error: "incorrect_client_credentials",
+            error_description: "The client_id and/or client_secret passed are incorrect.",
+          }),
+          headers: {
+            "Content-Type": "application/json; charset=utf-8"
+          }
+        }),
+    },
+  });
+
+  const auth = createAppAuth({
+    id: APP_ID,
+    privateKey: PRIVATE_KEY,
+    clientId: "12345678901234567890",
+    clientSecret: "1234567890123456789012345678901234567890",
+    request: requestMock,
+  });
+
+  await expect(
+    auth({
+      type: 'oauth',
+      code: '12345678901234567890',
+      redirectUrl: 'https://example.com/login',
+    })
+  ).rejects.toThrow('client_id');
+});


### PR DESCRIPTION
Fixes #26.

I've added a test and a fix. Let me know if you had something else in mind.

Jest is reporting missing branch coverage because I'm not testing the default value in case the response does not include an `error_description`. I introduced the default value just in case, but the [documentation](https://developer.github.com/apps/managing-oauth-apps/troubleshooting-oauth-app-access-token-request-errors/) I could find seems to always include `error_description`, so maybe it's not necessary.