### PR TITLE
fix: throw helpful error on `auth({ type: "installation" })` if `installationId` option is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const { createAppAuth } = require("@octokit/auth-app");
 </td></tr>
 <tr><td colspan=2>
 
-⚠️ For usage in browsers: The private keys provide by GitHub are in `PKCS#1` format, but the WebCrypto API only supports `PKCS#8`. You need to convert it first:
+⚠️ For usage in browsers: The private keys provided by GitHub are in `PKCS#1` format, but the WebCrypto API only supports `PKCS#8`. You need to convert it first:
 
 ```shell
 openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in private-key.pem -out private-key-pkcs8.key

--- a/src/get-installation-authentication.ts
+++ b/src/get-installation-authentication.ts
@@ -18,7 +18,7 @@ export async function getInstallationAuthentication(
 
   if (typeof installationId !== "number") {
     throw new Error(
-      "installationId is required for installation authtentication."
+      "[@octokit/auth-app] installationId option is required for installation authentication."
     );
   }
 

--- a/src/get-installation-authentication.ts
+++ b/src/get-installation-authentication.ts
@@ -16,6 +16,12 @@ export async function getInstallationAuthentication(
   const installationId = (options.installationId ||
     state.installationId) as number;
 
+  if (typeof installationId !== "number") {
+    throw new Error(
+      "installationId is required for installation authtentication."
+    );
+  }
+
   const optionsWithInstallationTokenFromState = Object.assign(
     { installationId },
     options

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -226,6 +226,46 @@ test("installationId strategy option", async () => {
   });
 });
 
+test("installationId strategy option fails with no installationId", async () => {
+  const requestMock = request.defaults({
+    headers: {
+      "user-agent": "test",
+    },
+    request: {
+      fetch: fetchMock
+        .sandbox()
+        .postOnce(
+          "https://api.github.com/app/installations/123/access_tokens",
+          {
+            token: "secret123",
+            expires_at: "1970-01-01T01:00:00.000Z",
+            permissions: {
+              metadata: "read",
+            },
+            repository_selection: "all",
+          }
+        ),
+    },
+  });
+
+  const auth = createAppAuth({
+    id: APP_ID,
+    privateKey: PRIVATE_KEY,
+    request: requestMock,
+  });
+
+  try {
+    await auth({
+      type: "installation",
+    });
+    expect(1).not.toBe(1);
+  } catch (e) {
+    expect(e).toEqual(
+      new Error("installationId is required for installation authtentication.")
+    );
+  }
+});
+
 test("repositoryIds auth option", async () => {
   const matchCreateInstallationAccessToken: MockMatcherFunction = (
     url,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -261,7 +261,9 @@ test("installationId strategy option fails with no installationId", async () => 
     expect(1).not.toBe(1);
   } catch (e) {
     expect(e).toEqual(
-      new Error("installationId is required for installation authtentication.")
+      new Error(
+        "[@octokit/auth-app] installationId option is required for installation authentication."
+      )
     );
   }
 });


### PR DESCRIPTION
An installationId is required in either `createAuthApp` or `auth` when using the installation auth type. This adds an error message to warn users when an installationId is missing.

Closes #64 