### PR TITLE
fix: do not remail trailing | from cache values

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -40,13 +40,6 @@ export async function get(
     singleFileName,
   ] = result.split("|");
 
-  /* istanbul ignore if - this is to debug an exception we see in production */
-  if (!options.permissions && typeof permissionsString === "undefined") {
-    throw new Error(
-      `[@octokit/auth-app] Invalid cache. Key: ${cacheKey}. Result: ${result}`
-    );
-  }
-
   const permissions =
     options.permissions ||
     permissionsString.split(/,/).reduce((permissions: Permissions, string) => {
@@ -91,9 +84,7 @@ export async function set(
     data.repositorySelection,
     permissionsString,
     data.singleFileName,
-  ]
-    .join("|")
-    .replace(/\|+$/, "");
+  ].join("|");
 
   await cache.set(key, value);
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1004,15 +1004,15 @@ test("supports custom cache", async () => {
   expect(get).toBeCalledWith("123");
   expect(set).toBeCalledWith(
     "123",
-    "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata"
+    "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata|"
   );
   expect(CACHE).toStrictEqual({
     "123":
-      "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata",
+      "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata|",
     "123|content":
-      "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all",
+      "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all||",
     "456":
-      "secret456|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata",
+      "secret456|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata|",
   });
 });
 
@@ -1066,7 +1066,7 @@ test("supports custom cache with async get/set", async () => {
   expect(get).toBeCalledWith("123");
   expect(set).toBeCalledWith(
     "123",
-    "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata"
+    "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata|"
   );
 });
 
@@ -1476,8 +1476,8 @@ test("auth.hook() and custom cache", async () => {
   expect(mock.done()).toBe(true);
   expect(CACHE).toStrictEqual({
     "123":
-      "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata",
+      "secret123|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata|",
     "456":
-      "secret456|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata",
+      "secret456|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata|",
   });
 });


### PR DESCRIPTION
This should workaround errors I see in production apps that seem to have permissions set in some cases