### PR TITLE
fix: better error message for missing param

### DIFF
--- a/src/get-installation-authentication.ts
+++ b/src/get-installation-authentication.ts
@@ -16,9 +16,15 @@ export async function getInstallationAuthentication(
   const installationId = (options.installationId ||
     state.installationId) as number;
 
-  if (typeof installationId !== "number") {
+  if (typeof installationId === "undefined") {
     throw new Error(
       "[@octokit/auth-app] installationId option is required for installation authentication."
+    );
+  }
+
+  if (typeof installationId !== "number") {
+    throw new Error(
+      "[@octokit/auth-app] installationId option should be of type number."
     );
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -268,6 +268,49 @@ test("installationId strategy option fails with no installationId", async () => 
   }
 });
 
+test("installationId strategy option fails with wrong installationId", async () => {
+  const requestMock = request.defaults({
+    headers: {
+      "user-agent": "test",
+    },
+    request: {
+      fetch: fetchMock
+        .sandbox()
+        .postOnce(
+          "https://api.github.com/app/installations/123/access_tokens",
+          {
+            token: "secret123",
+            expires_at: "1970-01-01T01:00:00.000Z",
+            permissions: {
+              metadata: "read",
+            },
+            repository_selection: "all",
+          }
+        ),
+    },
+  });
+
+  const auth = createAppAuth({
+    id: APP_ID,
+    privateKey: PRIVATE_KEY,
+    request: requestMock,
+  });
+
+  try {
+    await auth({
+      type: "installation",
+      installationId: "id123",
+    });
+    expect(1).not.toBe(1);
+  } catch (e) {
+    expect(e).toEqual(
+      new Error(
+        "[@octokit/auth-app] installationId option should be of type number."
+      )
+    );
+  }
+});
+
 test("repositoryIds auth option", async () => {
   const matchCreateInstallationAccessToken: MockMatcherFunction = (
     url,


### PR DESCRIPTION
This:

```js
{
    id: process.env.APP_ID,
    privateKey: process.env.PRIVATE_KEY,
    installationId: process.env.INSTALLATION_ID,
    clientId: process.env.CLIENT_ID,
    clientSecret: process.env.CLIENT_SECRET,
}
```

Results in this exception:

> Error: [@octokit/auth-app] installationId option is required for installation authentication.

It might take a while to understand that the ```installationId``` parameter is *not* missing as the error message suggests, but of the wrong type and should be parsed as int.
