### PR TITLE
feat: accept `id` and `installationId` options to be strings

### DIFF
--- a/src/get-installation-authentication.ts
+++ b/src/get-installation-authentication.ts
@@ -13,10 +13,9 @@ export async function getInstallationAuthentication(
   options: InstallationAuthOptions,
   customRequest?: RequestInterface
 ): Promise<InstallationAccessTokenAuthentication> {
-  const installationId = (options.installationId ||
-    state.installationId) as number;
+  const installationId = Number(options.installationId || state.installationId);
 
-  if (typeof installationId !== "number") {
+  if (!installationId) {
     throw new Error(
       "[@octokit/auth-app] installationId option is required for installation authentication."
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,13 @@ export const createAppAuth: StrategyInterface = function createAppAuth(
       }),
       cache: getCache(),
     },
-    options
+    options,
+    {
+      id: Number(options.id),
+    },
+    options.installationId
+      ? { installationId: Number(options.installationId) }
+      : {}
   );
 
   return Object.assign(auth.bind(null, state), {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,9 +74,9 @@ export type Authentication =
   | OAuthAccesTokenAuthentication;
 
 export type StrategyOptions = {
-  id: number;
+  id: number | string;
   privateKey: string;
-  installationId?: number;
+  installationId?: number | string;
   clientId?: string;
   clientSecret?: string;
   request?: OctokitTypes.RequestInterface;
@@ -84,6 +84,7 @@ export type StrategyOptions = {
 };
 
 export type StrategyOptionsWithDefaults = StrategyOptions & {
+  id: number;
   request: OctokitTypes.RequestInterface;
   cache: Cache;
 };
@@ -93,7 +94,7 @@ export type Permissions = {
 };
 
 export type InstallationAuthOptions = {
-  installationId?: number;
+  installationId?: number | string;
   repositoryIds?: number[];
   permissions?: Permissions;
   refresh?: boolean;
@@ -115,6 +116,8 @@ export type WithInstallationId = {
 };
 
 export type State = StrategyOptions & {
+  id: number;
+  installationId?: number;
   request: OctokitTypes.RequestInterface;
   cache: Cache;
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1475,3 +1475,39 @@ test("auth.hook() and custom cache", async () => {
       "secret456|1970-01-01T00:00:00.000Z|1970-01-01T01:00:00.000Z|all|metadata|",
   });
 });
+
+test("id and installationId can be passed as options", async () => {
+  const createInstallationAccessTokenResponseData = {
+    token: "secret123",
+    expires_at: "1970-01-01T01:00:00.000Z",
+    permissions: {
+      metadata: "read",
+    },
+    repository_selection: "all",
+  };
+
+  const auth = createAppAuth({
+    id: String(APP_ID),
+    privateKey: PRIVATE_KEY,
+    request: request.defaults({
+      headers: {
+        "user-agent": "test",
+      },
+      request: {
+        fetch: fetchMock
+          .sandbox()
+          .postOnce(
+            "https://api.github.com/app/installations/123/access_tokens",
+            createInstallationAccessTokenResponseData
+          ),
+      },
+    }),
+  });
+
+  const authentication = await auth({
+    type: "installation",
+    installationId: "123",
+  });
+
+  expect(authentication.token).toEqual("secret123");
+});


### PR DESCRIPTION
closes #149