### PR TITLE
fix(typescript): timeDifference is not a valid parameter

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,6 @@ export type StrategyOptions = {
   clientSecret?: string;
   request?: OctokitTypes.RequestInterface;
   cache?: Cache;
-  timeDifference?: number;
   log?: {
     warn: (message: string, additionalInfo?: object) => any;
     [key: string]: any;
@@ -125,6 +124,7 @@ export type State = StrategyOptions & {
   installationId?: number;
   request: OctokitTypes.RequestInterface;
   cache: Cache;
+  timeDifference?: number;
   log: {
     warn: (message: string, additionalInfo?: object) => any;
     [key: string]: any;


### PR DESCRIPTION
This moves the `timeDifference` key from `StrategyOptions` to `State`.
This is because `timeDifference` is only used internally in the state
object and not passed in by the user in the options parameter to
auth-app.

The types were not failing previously because the `State` type extends
the `StrategyOptions` type. However, `State` is the correct place for
this key to live.

Closes #199 