### PR TITLE
feat(auth): throw Error when auth type is not a valid one

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,13 +7,16 @@ export async function auth(
   state: State,
   options: AuthOptions
 ): Promise<Authentication> {
-  if (options.type === "app") {
-    return getAppAuthentication(state);
-  }
+  const { type } = options;
 
-  if (options.type === "installation") {
-    return getInstallationAuthentication(state, options);
+  switch (type) {
+    case "app":
+      return getAppAuthentication(state);
+    case "installation":
+      return getInstallationAuthentication(state, options);
+    case "oauth":
+      return getOAuthAuthentication(state, options);
+    default:
+      throw new Error(`Invalid auth type: ${type}`)
   }
-
-  return getOAuthAuthentication(state, options);
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -17,6 +17,6 @@ export async function auth(
     case "oauth":
       return getOAuthAuthentication(state, options);
     default:
-      throw new Error(`Invalid auth type: ${type}`)
+      throw new Error(`Invalid auth type: ${type}`);
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -64,6 +64,8 @@ test("throws if invalid 'type' is provided", async () => {
     privateKey: PRIVATE_KEY,
   });
 
+  // @ts-expect-error TS2322
+  // Details here: https://github.com/octokit/auth-app.js/issues/216#issuecomment-772106164
   expect(auth({ type: "app2" })).toThrow();
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -58,6 +58,15 @@ test("README example for app auth", async () => {
   });
 });
 
+test("throws if invalid 'type' is provided", async () => {
+  const auth = createAppAuth({
+    appId: APP_ID,
+    privateKey: PRIVATE_KEY,
+  });
+
+  expect(auth({ type: "app2" })).toThrow();
+});
+
 test("README example for installation auth", async () => {
   const matchCreateInstallationAccessToken: MockMatcherFunction = (
     url,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -66,7 +66,9 @@ test("throws if invalid 'type' is provided", async () => {
 
   // @ts-expect-error TS2322
   // Details here: https://github.com/octokit/auth-app.js/issues/216#issuecomment-772106164
-  expect(auth({ type: "app2" })).toThrow();
+  await expect(auth({ type: "app2" })).rejects.toEqual(
+    new Error("Invalid auth type: app2")
+  );
 });
 
 test("README example for installation auth", async () => {


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
throw Error when auth type is not a valid one

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix #216