### PR TITLE
feat(typescript): discriminate resolve type of `auth(options)` based on `options`

### DIFF
--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -4,6 +4,8 @@
 
 import { createAppAuth } from "../src";
 
+function expectType<T>(what: T) {}
+
 export async function readmeExample() {
   const auth = createAppAuth({
     appId: 1,
@@ -13,5 +15,7 @@ export async function readmeExample() {
   });
 
   // Retrieve an oauth-access token
-  await auth({ type: "oauth-user", code: "123456" });
+  const userAuthentication = await auth({ type: "oauth-user", code: "123456" });
+
+  expectType<"token">(userAuthentication.type);
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -6,16 +6,24 @@ import { createAppAuth } from "../src";
 
 function expectType<T>(what: T) {}
 
-export async function readmeExample() {
-  const auth = createAppAuth({
-    appId: 1,
-    privateKey: "-----BEGIN PRIVATE KEY-----\n...",
-    clientId: "lv1.1234567890abcdef",
-    clientSecret: "1234567890abcdef12341234567890abcdef1234",
-  });
+const auth = createAppAuth({
+  appId: 1,
+  privateKey: "-----BEGIN PRIVATE KEY-----\n...",
+  clientId: "lv1.1234567890abcdef",
+  clientSecret: "1234567890abcdef12341234567890abcdef1234",
+});
 
+export async function readmeExample() {
   // Retrieve an oauth-access token
   const userAuthentication = await auth({ type: "oauth-user", code: "123456" });
 
   expectType<"token">(userAuthentication.type);
+}
+
+export async function issue268() {
+  // Retrieve an oauth-access token
+  const userAuthentication = await auth({ type: "installation" });
+
+  expectType<"token">(userAuthentication.type);
+  expectType<"tokenType">(userAuthentication.tokenType);
 }


### PR DESCRIPTION
fixes #268
