### PR TITLE
fix: add webhook deliveries APIs

### DIFF
--- a/src/requires-app-auth.ts
+++ b/src/requires-app-auth.ts
@@ -1,6 +1,7 @@
 const PATHS = [
   "/app",
   "/app/hook/config",
+  "/app/hook/deliveries",
   "/app/installations",
   "/app/installations/{installation_id}",
   "/app/installations/{installation_id}/access_tokens",

--- a/src/requires-app-auth.ts
+++ b/src/requires-app-auth.ts
@@ -2,6 +2,8 @@ const PATHS = [
   "/app",
   "/app/hook/config",
   "/app/hook/deliveries",
+  "/app/hook/deliveries/{delivery_id}",
+  "/app/hook/deliveries/{delivery_id}/attempts",
   "/app/installations",
   "/app/installations/{installation_id}",
   "/app/installations/{installation_id}/access_tokens",


### PR DESCRIPTION
Hi,

I'm trying to use the new event redelivery api
The request are not working for me because it seams to want to use the installation token when I use the endpoint:
app/hook/deliveries?status=failure

I tried it from a probot app with:
```
const octokit = await app.auth();
const result2 = await octokit.request("GET /app/hook/deliveries", { status: "failure", mediaType: { previews: [mediaPreview] } });
```

I'm not sure about the other apis, if they need an installation token or an app bearer.
What do you think?