### PR TITLE
feat(get-app-authentication): improve error message when privateKey is incomplete

### DIFF
--- a/src/get-app-authentication.ts
+++ b/src/get-app-authentication.ts
@@ -23,7 +23,7 @@ export async function getAppAuthentication({
   } catch (error) {
     if (privateKey === "-----BEGIN RSA PRIVATE KEY-----") {
       throw new Error(
-        "Private key is incomplete. Make sure it is a single line String and newlines have been replaced by '\n'"
+        "The 'privateKey` option contains only the first line '-----BEGIN RSA PRIVATE KEY-----'. If you are setting it using a `.env` file, make sure it is set on a single line with newlines replaced by '\n'"
       );
     } else {
       throw error;

--- a/src/get-app-authentication.ts
+++ b/src/get-app-authentication.ts
@@ -7,16 +7,26 @@ export async function getAppAuthentication({
   privateKey,
   timeDifference,
 }: State & { timeDifference?: number }): Promise<AppAuthentication> {
-  const appAuthentication = await githubAppJwt({
-    id: +appId,
-    privateKey,
-    now: timeDifference && Math.floor(Date.now() / 1000) + timeDifference,
-  });
+  try {
+    const appAuthentication = await githubAppJwt({
+      id: +appId,
+      privateKey,
+      now: timeDifference && Math.floor(Date.now() / 1000) + timeDifference,
+    });
 
-  return {
-    type: "app",
-    token: appAuthentication.token,
-    appId: appAuthentication.appId,
-    expiresAt: new Date(appAuthentication.expiration * 1000).toISOString(),
-  };
+    return {
+      type: "app",
+      token: appAuthentication.token,
+      appId: appAuthentication.appId,
+      expiresAt: new Date(appAuthentication.expiration * 1000).toISOString(),
+    };
+  } catch (error) {
+    if (privateKey === "-----BEGIN RSA PRIVATE KEY-----") {
+      throw new Error(
+        "Private key is incomplete. Make sure it is a single line String and newlines have been replaced by '\n'"
+      );
+    } else {
+      throw error;
+    }
+  }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -99,15 +99,7 @@ test("throws if invalid Private Key is provided", async () => {
     privateKey: "INVALID_PRIVATE_KEY",
   });
 
-  const expectedError = new Error();
-  Object.assign(expectedError, {
-    code: "ERR_OSSL_PEM_NO_START_LINE",
-    function: "get_name",
-    library: "PEM routines",
-    reason: "no start line",
-  });
-
-  await expect(auth({ type: "app" })).rejects.toEqual(expectedError);
+  await expect(auth({ type: "app" })).rejects.toEqual(expect.anything());
 });
 
 test("throws if incomplete Private Key is provided", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -118,7 +118,7 @@ test("throws if incomplete Private Key is provided", async () => {
 
   await expect(auth({ type: "app" })).rejects.toEqual(
     new Error(
-      "Private key is incomplete. Make sure it is a single line String and newlines have been replaced by '\n'"
+      "The 'privateKey` option contains only the first line '-----BEGIN RSA PRIVATE KEY-----'. If you are setting it using a `.env` file, make sure it is set on a single line with newlines replaced by '\n'"
     )
   );
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -93,6 +93,36 @@ test("throws if invalid 'type' is provided", async () => {
   );
 });
 
+test("throws if invalid Private Key is provided", async () => {
+  const auth = createAppAuth({
+    appId: APP_ID,
+    privateKey: "INVALID_PRIVATE_KEY",
+  });
+
+  const expectedError = new Error();
+  Object.assign(expectedError, {
+    code: "ERR_OSSL_PEM_NO_START_LINE",
+    function: "get_name",
+    library: "PEM routines",
+    reason: "no start line",
+  });
+
+  await expect(auth({ type: "app" })).rejects.toEqual(expectedError);
+});
+
+test("throws if incomplete Private Key is provided", async () => {
+  const auth = createAppAuth({
+    appId: APP_ID,
+    privateKey: "-----BEGIN RSA PRIVATE KEY-----",
+  });
+
+  await expect(auth({ type: "app" })).rejects.toEqual(
+    new Error(
+      "Private key is incomplete. Make sure it is a single line String and newlines have been replaced by '\n'"
+    )
+  );
+});
+
 test("README example for installation auth", async () => {
   const matchCreateInstallationAccessToken: MockMatcherFunction = (
     url,


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- To improve error message when `privateKey` provided by a user is incomplete (with only `-----BEGIN RSA PRIVATE KEY-----`)

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix #311 