### PR TITLE
ci(test): downgrade sinonjs/faker-timers to v8 to 'test' checkrun

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@pika/plugin-build-node": "^0.9.0",
         "@pika/plugin-build-web": "^0.9.0",
         "@pika/plugin-ts-standard-pkg": "^0.9.0",
-        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/fake-timers": "^8.0.0",
         "@types/fetch-mock": "^7.3.1",
         "@types/jest": "^27.0.0",
         "@types/sinonjs__fake-timers": "^8.0.0",
@@ -2033,15 +2033,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/@jest/fake-timers/node_modules/@sinonjs/fake-timers": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
     "node_modules/@jest/globals": {
       "version": "27.2.5",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.5.tgz",
@@ -2716,9 +2707,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
+      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
@@ -12695,17 +12686,6 @@
         "jest-message-util": "^27.2.5",
         "jest-mock": "^27.2.5",
         "jest-util": "^27.2.5"
-      },
-      "dependencies": {
-        "@sinonjs/fake-timers": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-          "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          }
-        }
       }
     },
     "@jest/globals": {
@@ -13268,9 +13248,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
+      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@pika/plugin-build-node": "^0.9.0",
     "@pika/plugin-build-web": "^0.9.0",
     "@pika/plugin-ts-standard-pkg": "^0.9.0",
-    "@sinonjs/fake-timers": "^9.0.0",
+    "@sinonjs/fake-timers": "^8.0.0",
     "@types/fetch-mock": "^7.3.1",
     "@types/jest": "^27.0.0",
     "@types/sinonjs__fake-timers": "^8.0.0",


### PR DESCRIPTION
Fix #351 

---

I expect to address the proper fix with `sinonjs/fake-timers v9` when Renovate generates the associated PR.