### PR TITLE
ci(workflow): fix test workflow to assure it is not skipped if test_matrix fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on:
+"on":
   push:
     branches:
       - dependabot/npm_and_yarn/**
@@ -17,9 +17,9 @@ jobs:
           - 16
           - 18
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # tag=v3
+        uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm
@@ -29,6 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test_matrix
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+      - run: exit 1
+        if: ${{ needs.test_matrix.result != 'success' }}
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: npm ci
       - run: npm run test:typescript
+    if: ${{ always }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: npm ci
       - run: npm run test:typescript
-    if: ${{ always }}
+    if: ${{ always() }}


### PR DESCRIPTION
## Description
- Add `always()` condition to assure the workflow is not skipped if test_matrix fails
- Add logic to make the actual job fail if one of the tests of 'test_matrix' failed
## Context
https://github.com/octokit/auth-oauth-device.js/pull/74

---
🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-fix-test-workflow-octokit), feel free to run it in your GitHub user/org repositories! 💪🏾
