### PR TITLE
fix: throw helpful error when `appId` is not numeric

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,11 @@ export function createAppAuth(options: StrategyOptions): AuthInterface {
   if (!options.appId) {
     throw new Error("[@octokit/auth-app] appId option is required");
   }
+  if (!Number.isFinite(+options.appId)) {
+    throw new Error(
+      "[@octokit/auth-app] appId option must be a number or numeric string"
+    );
+  }
   if (!options.privateKey) {
     throw new Error("[@octokit/auth-app] privateKey option is required");
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2343,7 +2343,7 @@ test("Do not intercept auth.hook(request, 'POST https://github.com/login/oauth/a
   });
 });
 
-it("throws helpful error if `appId` is not set properly (#184)", async () => {
+it("throws helpful error if `appId` is not set (#184)", async () => {
   expect(() => {
     createAppAuth({
       // @ts-ignore
@@ -2351,6 +2351,17 @@ it("throws helpful error if `appId` is not set properly (#184)", async () => {
       privateKey: PRIVATE_KEY,
     });
   }).toThrowError("[@octokit/auth-app] appId option is required");
+});
+
+it("throws helpful error if `appId` is not set to a numeric value", async () => {
+  expect(() => {
+    createAppAuth({
+      appId: "not-a-number",
+      privateKey: PRIVATE_KEY,
+    });
+  }).toThrowError(
+    "[@octokit/auth-app] appId option must be a number or numeric string"
+  );
 });
 
 it("throws helpful error if `privateKey` is not set properly (#184)", async () => {


### PR DESCRIPTION
Currently the `appId` is checked only for a _truthy_ value, but it's actually required to be numeric, as well - [`getAppAuthentication`](https://github.com/octokit/auth-app.js/blob/524fc446d33ae5acfde702153adb127e8d786df9/src/get-app-authentication.ts#L12) assumes it is. If it is not, it results in the `iss` property of the JWT being set to `NaN` and causing an authentication failure. 

This adds an additional check to make sure `appId` is a finite number or can be coerced into a finite number.

partly addresses https://github.com/octokit/auth-app.js/issues/375