### PR TITLE
fix: `requiresAppAuth` was matching unintended URLs.

### DIFF
--- a/src/requires-app-auth.ts
+++ b/src/requires-app-auth.ts
@@ -57,5 +57,5 @@ function routeMatcher(paths: string[]) {
 const REGEX = routeMatcher(PATHS);
 
 export function requiresAppAuth(url: string | undefined): Boolean {
-  return !!url && REGEX.test(url);
+  return !!url && REGEX.test(url.split("?")[0]);
 }

--- a/src/requires-app-auth.ts
+++ b/src/requires-app-auth.ts
@@ -42,10 +42,10 @@ function routeMatcher(paths: string[]) {
       '/repos/(?:.+?)/(?:.+?)/collaborators/(?:.+?)'
   ] */
 
-  const regex = `^(?:${regexes.map((r) => `(?:${r})`).join("|")})[^/]*$`;
+  const regex = `^(?:${regexes.map((r) => `(?:${r})`).join("|")})$`;
   // 'regex' would contain:
   /*
-    ^(?:(?:\/orgs\/(?:.+?)\/invitations)|(?:\/repos\/(?:.+?)\/(?:.+?)\/collaborators\/(?:.+?)))[^\/]*$
+    ^(?:(?:\/orgs\/(?:.+?)\/invitations)|(?:\/repos\/(?:.+?)\/(?:.+?)\/collaborators\/(?:.+?)))$
 
     It may look scary, but paste it into https://www.debuggex.com/
     and it will make a lot more sense!

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2457,9 +2457,8 @@ test("auth.hook() uses app auth even for requests with query strings. (#374)", a
     },
   });
 
-  await requestWithAuth("GET /orgs/{org}/installation", {
+  await requestWithAuth("GET /orgs/{org}/installation?per_page=100", {
     org: "octocat",
-    per_page: 100,
   });
 
   expect(mock.done()).toBe(true);


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->

This fixed a bug where App authentication was occurring when attempting to get the list of installed apps in an organization. I have also tested the scenario where query strings are present, which was a concern raised in an issue. 

I am not very familiar with this library, so I would appreciate it if someone could thoroughly review it.

<!-- Issues are required for both bug fixes and features. -->
Resolves #374 (with @snicmakino)