### PR TITLE
Add private key validation check for multiline string content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,14 @@ export function createAppAuth(options: StrategyOptions): AuthInterface {
     );
   }
 
+  // This check ensures that private key contains the actual content
+  // specifically when set using envirnment variables as multiline string.
+  if (/^-----BEGIN .* PRIVATE KEY-----$/.test(options.privateKey.trim())) {
+    throw new Error(
+      "[@octokit/auth-app] privateKey only contains the first line. Try replacing line breaks with \n"
+    );
+  }
+
   const log = Object.assign(
     {
       warn: console.warn.bind(console),


### PR DESCRIPTION
Add private key validation check for multi-line string content specifically when set using environment variables as multi-line string.


<!-- Issues are required for both bug fixes and features. -->
Resolves [#465](https://github.com/octokit/auth-app.js/issues/465) [#71](https://github.com/gr2m/universal-github-app-jwt/issues/71)

----

## Behavior

### Before the change?
Failing due to passing multiline string to environment variables, See https://github.com/octokit/auth-app.js/issues/465#issuecomment-1564998327

*


### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- [x] Bugfix: `Type: Bug`
- [ ] Feature/model/API additions: `Type: Feature`
- [ ] Updates to docs or samples: `Type: Documentation`
- [ ] Dependencies/code cleanup: `Type: Maintenance`

----

