### PR TITLE
test(refactor): test(refactor): use 'toEqual' instead of 'toMatchObject' for Responses

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1853,7 +1853,7 @@ test("auth.hook(): handle 401 in first 5 seconds (#65)", async () => {
     expect(error.status).toEqual(401);
   }
 
-  expect(data).toMatchObject({ id: 123 });
+  expect(data).toEqual({ id: 123 });
   expect(mock.done()).toBe(true);
 
   // @ts-ignore


### PR DESCRIPTION
<!-- Issues are required for both bug fixes and features. -->
Resolves #506

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
Test assertions of Responses from `fetch-mock` are done with `jest.toMatchObject`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Test assertions of Responses from `fetch-mock` are done with `jest.toEqual`


### Other information
<!-- Any other information that is important to this PR  -->
More context in https://github.com/octokit/core.js/issues/588

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type
`Type: Maintenance`

----

