### PR TITLE
refactor: replace NodeJS internal module imports with `node:` specifier imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -14,9 +14,9 @@ import type {
   GitHubAppUserAuthenticationWithExpiration,
   OAuthWebFlowAuthOptions,
   OAuthDeviceFlowAuthOptions,
-} from "./types";
-import { getAppAuthentication } from "./get-app-authentication";
-import { getInstallationAuthentication } from "./get-installation-authentication";
+} from "./types.js";
+import { getAppAuthentication } from "./get-app-authentication.js";
+import { getInstallationAuthentication } from "./get-installation-authentication.js";
 
 /** GitHub App authentication */
 export async function auth(

--- a/src/get-app-authentication.ts
+++ b/src/get-app-authentication.ts
@@ -1,6 +1,6 @@
 import { githubAppJwt } from "universal-github-app-jwt";
 
-import type { AppAuthentication, State } from "./types";
+import type { AppAuthentication, State } from "./types.js";
 
 export async function getAppAuthentication({
   appId,

--- a/src/get-installation-authentication.ts
+++ b/src/get-installation-authentication.ts
@@ -1,12 +1,12 @@
-import { get, set } from "./cache";
-import { getAppAuthentication } from "./get-app-authentication";
-import { toTokenAuthentication } from "./to-token-authentication";
+import { get, set } from "./cache.js";
+import { getAppAuthentication } from "./get-app-authentication.js";
+import { toTokenAuthentication } from "./to-token-authentication.js";
 import type {
   InstallationAuthOptions,
   InstallationAccessTokenAuthentication,
   RequestInterface,
   State,
-} from "./types";
+} from "./types.js";
 
 export async function getInstallationAuthentication(
   state: State,

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,9 +1,9 @@
 import { requiresBasicAuth } from "@octokit/auth-oauth-user";
 import { RequestError } from "@octokit/request-error";
 
-import { getAppAuthentication } from "./get-app-authentication";
-import { getInstallationAuthentication } from "./get-installation-authentication";
-import { requiresAppAuth } from "./requires-app-auth";
+import { getAppAuthentication } from "./get-app-authentication.js";
+import { getInstallationAuthentication } from "./get-installation-authentication.js";
+import { requiresAppAuth } from "./requires-app-auth.js";
 import type {
   AnyResponse,
   EndpointOptions,
@@ -11,7 +11,7 @@ import type {
   RequestInterface,
   Route,
   State,
-} from "./types";
+} from "./types.js";
 
 const FIVE_SECONDS_IN_MS = 5 * 1000;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,11 @@ import { getUserAgent } from "universal-user-agent";
 import { request as defaultRequest } from "@octokit/request";
 import { createOAuthAppAuth } from "@octokit/auth-oauth-app";
 
-import { auth } from "./auth";
-import { hook } from "./hook";
-import { getCache } from "./cache";
-import type { AuthInterface, State, StrategyOptions } from "./types";
-import { VERSION } from "./version";
+import { auth } from "./auth.js";
+import { hook } from "./hook.js";
+import { getCache } from "./cache.js";
+import type { AuthInterface, State, StrategyOptions } from "./types.js";
+import { VERSION } from "./version.js";
 
 export { createOAuthUserAuth } from "@octokit/auth-oauth-user";
 export type {
@@ -25,7 +25,7 @@ export type {
   InstallationAccessTokenAuthentication,
   GitHubAppUserAuthentication,
   GitHubAppUserAuthenticationWithExpiration,
-} from "./types";
+} from "./types.js";
 
 export function createAppAuth(options: StrategyOptions): AuthInterface {
   if (!options.appId) {

--- a/src/to-token-authentication.ts
+++ b/src/to-token-authentication.ts
@@ -4,7 +4,7 @@ import type {
   WithInstallationId,
   TOKEN_TYPE,
   INSTALLATION_TOKEN_TYPE,
-} from "./types";
+} from "./types.js";
 
 export function toTokenAuthentication({
   installationId,

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -2,7 +2,7 @@ import { request } from "@octokit/request";
 import fetchMock, { MockMatcherFunction } from "fetch-mock";
 import { Deprecation } from "deprecation";
 
-import { createAppAuth } from "../src";
+import { createAppAuth } from "../src/index.ts";
 
 describe("deprecations", () => {
   test("auth({ type: 'oauth' }) - #263", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,7 @@ import fetchMock, { MockMatcherFunction } from "fetch-mock";
 import { request } from "@octokit/request";
 import { install } from "@sinonjs/fake-timers";
 
-import { createAppAuth, createOAuthUserAuth } from "../src/index";
+import { createAppAuth, createOAuthUserAuth } from "../src/index.ts";
 
 const APP_ID = 1;
 const PRIVATE_KEY = `-----BEGIN RSA PRIVATE KEY-----

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { createAppAuth, createOAuthUserAuth } from "../src";
+import { createAppAuth, createOAuthUserAuth } from "../src/index.ts";
 
 describe("smoke tests", () => {
   test("createAppAuth() is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -1,11 +1,12 @@
 {
-	"extends": "../tsconfig.json",
-	"compilerOptions": {
-		"emitDeclarationOnly": false,
-		"noEmit": true,
-		"verbatimModuleSyntax": false
-	},
-	"include": [
-		"src/**/*"
-	]
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
+  },
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.