### PR TITLE
fix: add /app/installation-requests to requires-app-auth paths

### DIFF
--- a/src/requires-app-auth.ts
+++ b/src/requires-app-auth.ts
@@ -8,6 +8,7 @@ const PATHS = [
   "/app/installations/{installation_id}",
   "/app/installations/{installation_id}/access_tokens",
   "/app/installations/{installation_id}/suspended",
+  "/app/installation-requests",
   "/marketplace_listing/accounts/{account_id}",
   "/marketplace_listing/plan",
   "/marketplace_listing/plans",


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
Resolves #593

Ensures [List Installation Requests for the Authenticated App](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#list-installation-requests-for-the-authenticated-app) use an app JWT

### Before the change?

Octokit requests to `GET /app/installation-requests` will throw the following error:
```
Error: [@octokit/auth-app] installationId option is required for installation authentication.
```

### After the change?

Octokit requests to `GET /app/installation-requests` will make the request with an app JWT.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

