### PR TITLE
feat: `appId` argument can be set to Client ID string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ name: Release
       - "*.x"
 # These are recommended by the semantic-release docs: https://github.com/semantic-release/npm#npm-provenance
 permissions:
-    contents: write # to be able to publish a GitHub release
-    issues: write # to be able to comment on released issues
-    pull-requests: write # to be able to comment on released pull requests
-    id-token: write # to enable use of OIDC for npm provenance
+  contents: write # to be able to publish a GitHub release
+  issues: write # to be able to comment on released issues
+  pull-requests: write # to be able to comment on released pull requests
+  id-token: write # to enable use of OIDC for npm provenance
 
 jobs:
   release:
@@ -25,7 +25,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npx semantic-release
+      - run: npx semantic-release@beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.OCTOKITBOT_NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/request-error": "^6.1.1",
         "@octokit/types": "^13.4.1",
         "lru-cache": "^10.0.0",
-        "universal-github-app-jwt": "^2.0.6",
+        "universal-github-app-jwt": "^2.2.0",
         "universal-user-agent": "^7.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@octokit/request-error": "^6.1.1",
     "@octokit/types": "^13.4.1",
     "lru-cache": "^10.0.0",
-    "universal-github-app-jwt": "^2.0.6",
+    "universal-github-app-jwt": "^2.2.0",
     "universal-user-agent": "^7.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -74,15 +74,6 @@
     }
   },
   "release": {
-    "branches": [
-      "+([0-9]).x",
-      "main",
-      "next",
-      {
-        "name": "beta",
-        "prerelease": true
-      }
-    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",

--- a/src/get-app-authentication.ts
+++ b/src/get-app-authentication.ts
@@ -6,10 +6,12 @@ export async function getAppAuthentication({
   appId,
   privateKey,
   timeDifference,
-}: State & { timeDifference?: number }): Promise<AppAuthentication> {
+}: State & {
+  timeDifference?: number;
+}): Promise<AppAuthentication> {
   try {
     const appAuthentication = await githubAppJwt({
-      id: +appId,
+      id: appId,
       privateKey,
       now: timeDifference && Math.floor(Date.now() / 1000) + timeDifference,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,7 @@ export function createAppAuth(options: StrategyOptions): AuthInterface {
   if (!options.appId) {
     throw new Error("[@octokit/auth-app] appId option is required");
   }
-  if (!Number.isFinite(+options.appId)) {
-    throw new Error(
-      "[@octokit/auth-app] appId option must be a number or numeric string",
-    );
-  }
+
   if (!options.privateKey) {
     throw new Error("[@octokit/auth-app] privateKey option is required");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,7 +152,7 @@ export type UTC_TIMESTAMP = string;
 export type AppAuthentication = {
   type: APP_TYPE;
   token: JWT;
-  appId: number;
+  appId: number | string;
   expiresAt: string;
 };
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2308,7 +2308,7 @@ it("throws helpful error if `appId` is not set (#184)", async () => {
   }).toThrowError("[@octokit/auth-app] appId option is required");
 });
 
-it("throws helpful error if `appId` is not set to a numeric value", async () => {
+it("allows passing an `appId` as a non numeric value", async () => {
   expect(() => {
     createAppAuth({
       appId: "Iv1.0123456789abcdef",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2311,12 +2311,10 @@ it("throws helpful error if `appId` is not set (#184)", async () => {
 it("throws helpful error if `appId` is not set to a numeric value", async () => {
   expect(() => {
     createAppAuth({
-      appId: "not-a-number",
+      appId: "Iv1.0123456789abcdef",
       privateKey: PRIVATE_KEY,
     });
-  }).toThrowError(
-    "[@octokit/auth-app] appId option must be a number or numeric string",
-  );
+  }).not.toThrow();
 });
 
 it("throws helpful error if `privateKey` is not set properly (#184)", async () => {

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -2,7 +2,12 @@
 // THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING
 // ************************************************************
 
+import { getAppAuthentication } from "../src/get-app-authentication.js";
+import { request } from "@octokit/request";
 import { createAppAuth } from "../src/index.js";
+import { State, StrategyOptions } from "../src/types.js";
+import { getCache } from "../src/cache.js";
+import { createOAuthAppAuth } from "@octokit/auth-oauth-app";
 function isString(what: string) {}
 
 export async function readmeExample() {
@@ -30,4 +35,41 @@ export async function issue282() {
   });
 
   isString(authentication.token);
+}
+
+// https://github.com/octokit/auth-app.js/issues/603
+export async function issue603() {
+  createAppAuth({
+    appId: "1",
+    privateKey: "",
+  });
+
+  const options: StrategyOptions = {
+    appId: "1",
+    privateKey: "",
+  };
+
+  const state: State = Object.assign(
+    {
+      request,
+      cache: getCache(),
+    },
+    options,
+    options.installationId
+      ? { installationId: Number(options.installationId) }
+      : {},
+    {
+      log: {
+        warn: console.warn.bind(console),
+      },
+      oauthApp: createOAuthAppAuth({
+        clientType: "github-app",
+        clientId: options.clientId || "",
+        clientSecret: options.clientSecret || "",
+        request,
+      }),
+    },
+  );
+
+  getAppAuthentication(state);
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -40,12 +40,12 @@ export async function issue282() {
 // https://github.com/octokit/auth-app.js/issues/603
 export async function issue603() {
   createAppAuth({
-    appId: "1",
+    appId: "Iv1.0123456789abcdef",
     privateKey: "",
   });
 
   const options: StrategyOptions = {
-    appId: "1",
+    appId: "Iv1.0123456789abcdef",
     privateKey: "",
   };
 


### PR DESCRIPTION
- **feat(types): `appId` allows string or number as type**
- **test(types): add test coverage for appId new type**

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #603 

----

### Before the change?
`appId` only allowed `number` as type.

### After the change?
`appId` allows `number` or `string` as type.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

