### PR TITLE
fix: respect `baseUrl` passed as part of request parameters

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -63,7 +63,7 @@ export async function hook(
       const diff = Math.floor(
         (Date.parse(error.response.headers.date) -
           Date.parse(new Date().toString())) /
-        1000,
+          1000,
       );
 
       state.log.warn(error.message);
@@ -92,7 +92,8 @@ export async function hook(
     state,
     // @ts-expect-error TBD
     {},
-    request.defaults({ baseUrl: endpoint.baseUrl }),
+    // request.defaults({ baseUrl: endpoint.baseUrl }),
+    request,
   );
 
   endpoint.headers.authorization = `token ${token}`;
@@ -131,8 +132,9 @@ async function sendRequestWithRetries(
 
     if (timeSinceTokenCreationInMs >= FIVE_SECONDS_IN_MS) {
       if (retries > 0) {
-        error.message = `After ${retries} retries within ${timeSinceTokenCreationInMs / 1000
-          }s of creating the installation access token, the response remains 401. At this point, the cause may be an authentication problem or a system outage. Please check https://www.githubstatus.com for status information`;
+        error.message = `After ${retries} retries within ${
+          timeSinceTokenCreationInMs / 1000
+        }s of creating the installation access token, the response remains 401. At this point, the cause may be an authentication problem or a system outage. Please check https://www.githubstatus.com for status information`;
       }
       throw error;
     }
@@ -141,7 +143,8 @@ async function sendRequestWithRetries(
 
     const awaitTime = retries * 1000;
     state.log.warn(
-      `[@octokit/auth-app] Retrying after 401 response to account for token replication delay (retry: ${retries}, wait: ${awaitTime / 1000
+      `[@octokit/auth-app] Retrying after 401 response to account for token replication delay (retry: ${retries}, wait: ${
+        awaitTime / 1000
       }s)`,
     );
     await new Promise((resolve) => setTimeout(resolve, awaitTime));

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -63,7 +63,7 @@ export async function hook(
       const diff = Math.floor(
         (Date.parse(error.response.headers.date) -
           Date.parse(new Date().toString())) /
-          1000,
+        1000,
       );
 
       state.log.warn(error.message);
@@ -92,7 +92,7 @@ export async function hook(
     state,
     // @ts-expect-error TBD
     {},
-    request,
+    request.defaults({ baseUrl: endpoint.baseUrl }),
   );
 
   endpoint.headers.authorization = `token ${token}`;
@@ -131,9 +131,8 @@ async function sendRequestWithRetries(
 
     if (timeSinceTokenCreationInMs >= FIVE_SECONDS_IN_MS) {
       if (retries > 0) {
-        error.message = `After ${retries} retries within ${
-          timeSinceTokenCreationInMs / 1000
-        }s of creating the installation access token, the response remains 401. At this point, the cause may be an authentication problem or a system outage. Please check https://www.githubstatus.com for status information`;
+        error.message = `After ${retries} retries within ${timeSinceTokenCreationInMs / 1000
+          }s of creating the installation access token, the response remains 401. At this point, the cause may be an authentication problem or a system outage. Please check https://www.githubstatus.com for status information`;
       }
       throw error;
     }
@@ -142,8 +141,7 @@ async function sendRequestWithRetries(
 
     const awaitTime = retries * 1000;
     state.log.warn(
-      `[@octokit/auth-app] Retrying after 401 response to account for token replication delay (retry: ${retries}, wait: ${
-        awaitTime / 1000
+      `[@octokit/auth-app] Retrying after 401 response to account for token replication delay (retry: ${retries}, wait: ${awaitTime / 1000
       }s)`,
     );
     await new Promise((resolve) => setTimeout(resolve, awaitTime));

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -92,8 +92,7 @@ export async function hook(
     state,
     // @ts-expect-error TBD
     {},
-    // request.defaults({ baseUrl: endpoint.baseUrl }),
-    request,
+    request.defaults({ baseUrl: endpoint.baseUrl }),
   );
 
   endpoint.headers.authorization = `token ${token}`;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2416,3 +2416,55 @@ test("auth.hook() uses app auth even for requests with query strings. (#374)", a
 
   expect(mock.done()).toBe(true);
 });
+
+test("auth.hook() respects `baseUrl` passed as part of request parameters #640", async () => {
+  const mock = fetchMock
+    .sandbox()
+    .postOnce(
+      "https://not-api.github.com/app/installations/123/access_tokens",
+      {
+        token: "secret123",
+        expires_at: "1970-01-01T01:00:00.000Z",
+        permissions: {
+          metadata: "read",
+        },
+        repository_selection: "all",
+      },
+    )
+    .get(
+      "https://not-api.github.com/repos/octocat/hello-world",
+      { id: 123 },
+      {
+        headers: {
+          authorization: "token secret123",
+        },
+        repeat: 4,
+      },
+    );
+
+  const auth = createAppAuth({
+    appId: APP_ID,
+    privateKey: PRIVATE_KEY,
+    installationId: 123,
+  });
+
+  const requestWithMock = request.defaults({
+    headers: {
+      "user-agent": "test",
+    },
+    request: {
+      fetch: mock,
+    },
+  });
+  const requestWithAuth = requestWithMock.defaults({
+    request: {
+      hook: auth.hook,
+    },
+  });
+
+  const { data } = await requestWithAuth("GET /repos/octocat/hello-world", {
+    baseUrl: "https://not-api.github.com",
+  });
+
+  expect(data).toEqual({ id: 123 });
+});


### PR DESCRIPTION
closes #640