### PR TITLE
fix: respect `baseUrl` passed as part of request parameters

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -92,7 +92,7 @@ export async function hook(
     state,
     // @ts-expect-error TBD
     {},
-    request,
+    request.defaults({ baseUrl: endpoint.baseUrl }),
   );
 
   endpoint.headers.authorization = `token ${token}`;


### PR DESCRIPTION
applies fix from #641 to `6.x`