### PR TITLE
fix: replace lru-cache with toad-cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@octokit/request": "^9.1.1",
         "@octokit/request-error": "^6.1.1",
         "@octokit/types": "^13.4.1",
-        "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+        "toad-cache": "^3.7.0",
         "universal-github-app-jwt": "^2.2.0",
         "universal-user-agent": "^7.0.0"
       },
@@ -1692,16 +1692,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "name": "@wolfy1339/lru-cache",
-      "version": "11.0.2-patch.1",
-      "resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
-      "integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
-      "license": "ISC",
-      "engines": {
-        "node": "18 >=18.20 || 20 || >=22"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.12",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
@@ -2413,6 +2403,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/totalist": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@octokit/request": "^9.1.1",
     "@octokit/request-error": "^6.1.1",
     "@octokit/types": "^13.4.1",
-    "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+    "toad-cache": "^3.7.0",
     "universal-github-app-jwt": "^2.2.0",
     "universal-user-agent": "^7.0.0"
   },

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,4 @@
-// https://github.com/isaacs/node-lru-cache#readme
-import { LRUCache } from "lru-cache";
+import { Lru } from "toad-cache";
 
 /* v8 ignore next */
 import type {
@@ -12,12 +11,12 @@ import type {
 } from "./types.js";
 
 export function getCache() {
-  return new LRUCache<number, string>({
+  return new Lru<string>(
     // cache max. 15000 tokens, that will use less than 10mb memory
-    max: 15000,
+    15000,
     // Cache for 1 minute less than GitHub expiry
-    ttl: 1000 * 60 * 59,
-  });
+    1000 * 60 * 59,
+  );
 }
 
 export async function get(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type * as OctokitTypes from "@octokit/types";
-import type { LRUCache } from "lru-cache";
+import type { Lru } from "toad-cache";
 import type * as OAuthAppAuth from "@octokit/auth-oauth-app";
 
 // STRATEGY OPTIONS
@@ -134,7 +134,7 @@ export type Route = OctokitTypes.Route;
 export type RequestInterface = OctokitTypes.RequestInterface;
 
 export type Cache =
-  | LRUCache<string, string>
+  | Lru<string>
   | {
       get: (key: string) => string | Promise<string>;
       set: (key: string, value: string) => any;


### PR DESCRIPTION
This replaces lru-cache with toad-cache by @kibertoad

We use this in fastify and have good experience with it.