### PR TITLE
feat: handling exp is too far in the future

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -16,7 +16,9 @@ import type {
 const FIVE_SECONDS_IN_MS = 5 * 1000;
 
 function isNotTimeSkewError(error: RequestError) {
-  return !(
+  return !(error.message.match(
+      /'Expiration time' claim \('exp'\) is too far in the future/,
+    ) ||
     error.message.match(
       /'Expiration time' claim \('exp'\) must be a numeric value representing the future time at which the assertion expires/,
     ) ||


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #698

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* In case we send a exp more than 10minutes in future github responds with a 401 error which is not handled

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* If github responds with 'Expiration time' claim ('exp') is too far in the future' we regenerate the token using github date from response

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

