### PR TITLE
docs: document that `appId` accepts a Client ID string

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,10 +357,10 @@ await installationOctokit.request("POST /repos/{owner}/{repo}/issues", {
         <code>appId</code>
       </th>
       <th>
-        <code>number</code>
+        <code>number | string</code>
       </th>
       <td>
-        <strong>Required</strong>. Find <strong>App ID</strong> on the app’s about page in settings.
+        <strong>Required</strong>. Find <strong>App ID</strong> on the app’s about page in settings. A <strong>Client ID</strong> string may also be used and is recommended.
       </td>
     </tr>
     <tr>
@@ -923,10 +923,10 @@ Depending on on the `auth()` call, the resulting authentication object can be on
         <code>appId</code>
       </th>
       <th>
-        <code>number</code>
+        <code>number | string</code>
       </th>
       <td>
-        GitHub App database ID.
+        GitHub App database ID or Client ID.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Resolves #635

----

### Before the change?

* The README documents `appId` as type `number` in both the `createAppAuth(options)` table and the JWT authentication response table, with no mention that a Client ID string is also accepted.

### After the change?

* The `appId` type is documented as `number | string` in both tables.
* The `createAppAuth(options)` description notes that a **Client ID** string (e.g. `"Iv23ct7ycNNTMv43gXI7"`) may be used and is recommended.
* The JWT authentication response description reflects that `appId` may be a database ID or Client ID.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
